### PR TITLE
chore: Remove un-needed suffix to deployment name

### DIFF
--- a/manifests/run/base/deployment.yaml
+++ b/manifests/run/base/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kube-ns-suspender-deployment
+  name: kube-ns-suspender
   labels:
     app: kube-ns-suspender
   namespace: kube-ns-suspender


### PR DESCRIPTION
The suffix was redondant with the `kind` of the object