### PR TITLE
refactor: logs

### DIFF
--- a/engine/suspender.go
+++ b/engine/suspender.go
@@ -15,25 +15,25 @@ import (
 // it will read and write namespaces' annotations, and scale resources.
 func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 	eng.Mutex.Lock()
-	eng.RunningNamespacesList = make(map[string]time.Time)
 	eng.Logger.Info().Str("routine", "suspender").Msg("suspender started")
 
+	var stepName string
 	for {
+		// QUESTION: Why unlocking here ?
 		eng.Mutex.Unlock()
+
 		// wait for the next namespace to check
 		n := <-eng.Wl
 		start := time.Now()
 
-		// we create a sublogger to avoid "namespace" field duplication at each
-		// loop
+		// we create a sublogger to avoid "namespace" field duplication at each loop
 		eng.Mutex.Lock()
 		sLogger := eng.Logger.With().Str("routine", "suspender").Str("namespace", n.Name).Logger()
-		sLogger.Trace().Msgf("namespace received from watcher")
-
-		// get the namespace state
-		dState := n.Annotations[eng.Options.Prefix+DesiredState]
+		sLogger.Debug().Msg("namespace received from watcher")
 
 		/*
+			Step 1
+
 			This first switch-case statement will ensure that the namespace has a state set.
 			- if dState is empty, it means that it is the first time we see this namespace, so we
 			add the annotation with the state Running
@@ -41,63 +41,77 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			- if dState ends in the default case, it means that the state has not been recognised, so
 			we have to error
 		*/
-
+		stepName = "define namespace state from annotation"
+		sLogger.Debug().Str("step", stepName).Msg("starting step")
+		dState := n.Annotations[eng.Options.Prefix+DesiredState]
 		switch dState {
 		case "":
-			sLogger.Debug().Msgf("namespace has no %s annotation, it is probably the first time I see it", DesiredState)
+			sLogger.Debug().Str("step", stepName).Msgf("namespace has no '%s' annotation, it is probably the first time I see it", eng.Options.Prefix+DesiredState)
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				sLogger.Trace().Int("step", 1).Msg("get namespace")
 				res, err := cs.CoreV1().Namespaces().Get(ctx, n.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 				// we set the annotation to running
+				sLogger.Trace().Str("step", stepName).Msgf("setting namespace annotation '%s=%s'", eng.Options.Prefix+DesiredState, Running)
 				res.Annotations[eng.Options.Prefix+DesiredState] = Running
 
+				sLogger.Trace().Str("step", stepName).Msg("updating namespace")
 				_, err = cs.CoreV1().Namespaces().Update(ctx, res, metav1.UpdateOptions{})
 				return err
 			}); err != nil {
-				sLogger.Error().Err(err).Msgf("cannot update namespace object")
+				sLogger.Error().Err(err).Msg("cannot update namespace object")
 				// we give up and handle the next namespace
-				sLogger.Debug().Msgf("suspender loop ended, duration: %s", time.Since(start))
+				sLogger.Debug().Str("step", stepName).Msgf("suspender loop ended, duration: %s", time.Since(start))
 				continue
 			}
-			sLogger.Debug().Msgf("added annotation %s=%s to namespace", DesiredState, Running)
+			sLogger.Debug().Str("step", stepName).Msgf("added annotation '%s=%s' to namespace", eng.Options.Prefix+DesiredState, Running)
 
 			// we now update the value of dState to match the new namespace annotation
+			sLogger.Debug().Str("step", stepName).Msgf("updating internal state to '%s'", Running)
 			dState = Running
 		case Running, Suspended:
-			// do nothing
+			sLogger.Debug().Str("step", stepName).Msgf("found annotation '%s=%s'", eng.Options.Prefix+DesiredState, dState)
 		default:
 			sLogger.Error().Err(errors.New("state not recognised: "+dState)).Msgf("state %s is not recognised", dState)
 			// we give up and handle the next namespace
-			sLogger.Debug().Msgf("suspender loop ended, duration: %s", time.Since(start))
+			sLogger.Debug().Str("step", stepName).Msgf("suspender loop ended, duration: %s", time.Since(start))
 			continue
 		}
 
 		/*
-			In order to be able to edit the resources, we first need to get all of them from
-			the namespace. This is the goal of the following expressions
-		*/
+			Step 2
 
+			In order to be able to edit the resources, we first need to get all of them from
+			the namespace.
+		*/
+		stepName = "get namespace resources"
 		// get deployments of the namespace
+		sLogger.Debug().Str("step", stepName).Msg("getting namespace resources to manage")
+		sLogger.Debug().Str("step", stepName).Str("resource", "deployments").Msg("get resource from k8s")
 		deployments, err := cs.AppsV1().Deployments(n.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			sLogger.Fatal().Err(err).Msg("cannot list deployments")
 		}
 
 		// get cronjobs of the namespace
+		sLogger.Debug().Str("step", stepName).Str("resource", "cronjobs").Msg("get resource from k8s")
 		cronjobs, err := cs.BatchV1beta1().CronJobs(n.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			sLogger.Fatal().Err(err).Msg("cannot list cronjobs")
 		}
 
 		// get statefulsets of the namespace
+		sLogger.Debug().Str("step", stepName).Str("resource", "statefulsets").Msg("get resource from k8s")
 		statefulsets, err := cs.AppsV1().StatefulSets(n.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			sLogger.Fatal().Err(err).Msg("cannot list statefulsets")
 		}
 
 		/*
+			Step 3
+
 			If we end up here, it means that:
 			- the namespace has a desiredState annotation
 			- the annotation is valid
@@ -128,16 +142,19 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			- now, which contains today's time
 			- suspendAt, which contains today's suspend time for the namespace
 		*/
-
+		stepName = "handle desiredState"
 		var now, suspendAt int
 	LOOP:
-		sLogger.Debug().Msgf("namespace is seen as being %s", dState)
+		sLogger.Debug().Str("step", stepName).Msgf("namespace is seen as being '%s'", dState)
 		switch dState {
 		case Suspended:
+			sLogger.Debug().Str("step", stepName).Msg("checking suspended Conformity")
 			// the checks will be done concurrently to optimise verification duration
 			var wg sync.WaitGroup
 			wg.Add(3)
+
 			// check and patch deployments
+			sLogger.Debug().Str("step", stepName).Str("resource", "deployments").Msg("checking suspended Conformity")
 			go func() {
 				if err := checkSuspendedDeploymentsConformity(ctx, sLogger, deployments.Items, cs, n.Name, eng.Options.Prefix); err != nil {
 					sLogger.Error().Err(err).Str("object", "deployment").Msg("suspended conformity checks failed")
@@ -146,6 +163,7 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			}()
 
 			// check and patch cronjobs
+			sLogger.Debug().Str("step", stepName).Str("resource", "cronjobs").Msg("checking suspended Conformity")
 			go func() {
 				if err := checkSuspendedCronjobsConformity(ctx, sLogger, cronjobs.Items, cs, n.Name); err != nil {
 					sLogger.Error().Err(err).Str("object", "cronjob").Msg("suspended cronjobs conformity checks failed")
@@ -154,6 +172,7 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			}()
 
 			// check and patch statefulsets
+			sLogger.Debug().Str("step", stepName).Str("resource", "statefulsets").Msg("checking suspended Conformity")
 			go func() {
 				if err := checkSuspendedStatefulsetsConformity(ctx, sLogger, statefulsets.Items, cs, n.Name, eng.Options.Prefix); err != nil {
 					sLogger.Error().Err(err).Str("object", "statefulset").Msg("suspended steatfulsets conformity checks failed")
@@ -162,34 +181,44 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			}()
 			// we wait for all the checks to be done
 			wg.Wait()
+			sLogger.Debug().Str("step", stepName).Msg("checking suspended Conformity done")
+
 		case Running:
-			// we ensure that the annotation DailySuspendTime is set
+			// QUESTION: Shouldn't this section be part of switch in step 1 ?
+			// check DailySuspendTime annotation
+			sLogger.Debug().Str("step", stepName).Msgf("checking annotation '%s'", eng.Options.Prefix+DailySuspendTime)
 			now, suspendAt, err = getTimes(n.Annotations[eng.Options.Prefix+DailySuspendTime])
 			if err != nil {
-				sLogger.Warn().Err(err).Msgf("cannot parse %s annotation on namespace", DailySuspendTime)
-				sLogger.Debug().Msgf("suspender loop ended, duration: %s", time.Since(start))
+				sLogger.Warn().Err(err).Msgf("cannot parse '%s' annotation on namespace", eng.Options.Prefix+DailySuspendTime)
 			}
 
 			// check if dailySuspendTime is set and past
 			if err == nil && suspendAt <= now {
-				sLogger.Debug().Msgf("%s is less or equal to now (value: %d, now: %d), updating annotation to %s", DailySuspendTime, suspendAt, now, Suspended)
+				sLogger.Debug().
+					Str("step", stepName).
+					Msgf("%s is less or equal to now (value: %d, now: %d), updating annotation '%s' to '%s'", DailySuspendTime, suspendAt, now, eng.Options.Prefix+DesiredState, Suspended)
+
+				// NOTICE: Seems same content than L51-L69
 				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					sLogger.Trace().Str("step", stepName).Msg("get namespace")
 					res, err := cs.CoreV1().Namespaces().Get(ctx, n.Name, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
 					// we set the annotation to suspended
+					sLogger.Trace().Str("step", stepName).Msgf("setting namespace annotation '%s=%s'", eng.Options.Prefix+DesiredState, Suspended)
 					res.Annotations[eng.Options.Prefix+DesiredState] = Suspended
 
+					sLogger.Trace().Str("step", stepName).Msg("updating namespace")
 					_, err = cs.CoreV1().Namespaces().Update(ctx, res, metav1.UpdateOptions{})
 					return err
 				}); err != nil {
-					sLogger.Error().Err(err).Msgf("cannot update namespace object")
+					sLogger.Error().Err(err).Msg("cannot update namespace object")
 					// we give up and handle the next namespace
-					sLogger.Debug().Msgf("suspender loop ended, duration: %s", time.Since(start))
+					sLogger.Debug().Str("step", stepName).Msgf("suspender loop ended, duration: %s", time.Since(start))
 					continue
 				} else {
-					sLogger.Debug().Msgf("added annotation %s=%s to namespace, going back to the start of the switch-case", DesiredState, Suspended)
+					sLogger.Debug().Str("step", stepName).Msgf("added annotation '%s=%s' to namespace, going back to the start of the switch-case", DesiredState, Suspended)
 
 					// we now update the value of dState to match the new namespace annotation
 					dState = Suspended
@@ -201,32 +230,38 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			}
 
 			// check if nextSuspendTime exists and is past
+			sLogger.Debug().Str("step", stepName).Msgf("checking annotation '%s'", eng.Options.Prefix+nextSuspendTime)
 			if val, ok := n.Annotations[eng.Options.Prefix+nextSuspendTime]; ok {
 				nextSuspendAt, err := time.Parse(time.RFC822Z, val)
 				if err != nil {
-					sLogger.Error().Err(err).Msgf("cannot parse %s value %s in time format %s for namespace", nextSuspendTime, val, time.RFC822Z)
+					sLogger.Error().Err(err).Msgf("cannot parse '%s' value '%s' in time format '%s'", nextSuspendTime, val, time.RFC822Z)
 					continue
 				}
 
 				if time.Now().Local().Sub(nextSuspendAt) <= eng.RunningDuration {
-					sLogger.Debug().Msgf("%s is less or equal to now (value: %d, now: %d), updating annotation to %s", nextSuspendTime, suspendAt, now, Suspended)
+					// NOTICE: Same code than L200-L228
+					sLogger.Debug().Str("step", stepName).
+						Msgf("%s is less or equal to now (value: %d, now: %d), updating annotation '%s' to '%s'", nextSuspendTime, suspendAt, now, eng.Options.Prefix+DesiredState, Suspended)
 					if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						sLogger.Trace().Str("step", stepName).Msg("get namespace")
 						res, err := cs.CoreV1().Namespaces().Get(ctx, n.Name, metav1.GetOptions{})
 						if err != nil {
 							return err
 						}
 						// we set the annotation to suspended
+						sLogger.Trace().Str("step", stepName).Msgf("setting namespace annotation '%s=%s'", eng.Options.Prefix+DesiredState, Suspended)
 						res.Annotations[eng.Options.Prefix+DesiredState] = Suspended
 
+						sLogger.Trace().Str("step", stepName).Msg("updating namespace")
 						_, err = cs.CoreV1().Namespaces().Update(ctx, res, metav1.UpdateOptions{})
 						return err
 					}); err != nil {
-						sLogger.Error().Err(err).Msgf("cannot update namespace object")
+						sLogger.Error().Err(err).Msg("cannot update namespace object")
 						// we give up and handle the next namespace
-						sLogger.Debug().Msgf("suspender loop ended, duration: %s", time.Since(start))
+						sLogger.Debug().Str("step", stepName).Msgf("suspender loop ended, duration: %s", time.Since(start))
 						continue
 					} else {
-						sLogger.Debug().Msgf("added annotation %s=%s to namespace, going back to the start of the switch-case", DesiredState, Suspended)
+						sLogger.Debug().Str("step", stepName).Msgf("added annotation '%s=%s' to namespace, going back to the start of the switch-case", DesiredState, Suspended)
 
 						// we now update the value of dState to match the new namespace annotation
 						dState = Suspended
@@ -239,6 +274,8 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			}
 
 			/*
+				Step 4
+
 				If we end up here, it means that the namespace should be running. All we have to do now is to
 				run the conformity checks on the namespace resources.
 
@@ -250,49 +287,62 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 			*/
 			var wg sync.WaitGroup
 			var patchedResourcesCounter int
+
+			sLogger.Debug().Str("step", stepName).Msgf("namespace is seen as being '%s'", dState)
 			wg.Add(3)
+
+			sLogger.Debug().Str("step", stepName).Msg("checking running conformity")
+
 			// check and patch deployments
+			sLogger.Debug().Str("step", stepName).Str("resource", "deployments").Msg("checking running conformity")
 			go func() {
 				hasBeenPatched, err := checkRunningDeploymentsConformity(ctx, sLogger, deployments.Items, cs, n.Name, eng.Options.Prefix)
 				if err != nil {
 					sLogger.Error().Err(err).Msg("running deployments conformity checks failed")
 				}
 				if hasBeenPatched {
+					sLogger.Debug().Str("step", stepName).Str("resource", "deployments").Msg("resource has been patched")
 					patchedResourcesCounter++
 				}
 				wg.Done()
 			}()
 
 			// check and patch cronjobs
+			sLogger.Debug().Str("step", stepName).Str("resource", "cronjobs").Msg("checking running conformity")
 			go func() {
 				hasBeenPatched, err := checkRunningCronjobsConformity(ctx, sLogger, cronjobs.Items, cs, n.Name)
 				if err != nil {
 					sLogger.Error().Err(err).Msg("running cronjobs conformity checks failed")
 				}
 				if hasBeenPatched {
+					sLogger.Debug().Str("step", stepName).Str("resource", "cronjobs").Msg("resource has been patched")
 					patchedResourcesCounter++
 				}
 				wg.Done()
 			}()
 
 			// check and patch statefulsets
+			sLogger.Debug().Str("step", stepName).Str("resource", "statefulsets").Msg("checking running conformity")
 			go func() {
 				hasBeenPatched, err := checkRunningStatefulsetsConformity(ctx, sLogger, statefulsets.Items, cs, n.Name, eng.Options.Prefix)
 				if err != nil {
 					sLogger.Error().Err(err).Msg("running steatfulsets conformity checks failed")
 				}
 				if hasBeenPatched {
+					sLogger.Debug().Str("step", stepName).Str("resource", "statefulsets").Msg("resource has been patched")
 					patchedResourcesCounter++
 				}
 				wg.Done()
 			}()
 			// we wait for all the checks to be done
 			wg.Wait()
+			sLogger.Debug().Str("step", stepName).Msg("checking running conformity done")
 
 			// now we can check if patchedResourcesCounter is > 0 and add nextSuspendTime depending of the result
 			if patchedResourcesCounter > 0 {
-				sLogger.Debug().Msgf("it seems that namespace has been unsuspended manually, so I am adding the annotation %s to it", n.Name, nextSuspendTime)
+				sLogger.Debug().Msgf("namespace has been unsuspended manually, adding the annotation '%s' to it", eng.Options.Prefix+nextSuspendTime)
 				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					sLogger.Trace().Str("step", stepName).Msg("get namespace")
 					res, err := cs.CoreV1().Namespaces().Get(ctx, n.Name, metav1.GetOptions{})
 					if err != nil {
 						return err
@@ -306,17 +356,19 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 						However, it makes it easier to detect if the date is passed, as it returns
 						a complete date, not only the hours and minutes of the day.
 					*/
+					sLogger.Trace().Str("step", stepName).Msgf("setting namespace annotation '%s=%s'", eng.Options.Prefix+nextSuspendTime, time.Now().Local())
 					res.Annotations[eng.Options.Prefix+nextSuspendTime] = time.Now().Local().
 						Add(eng.RunningDuration).Format(time.RFC822Z)
 
+					sLogger.Trace().Str("step", stepName).Msg("update namespace")
 					_, err = cs.CoreV1().Namespaces().Update(ctx, res, metav1.UpdateOptions{})
 					return err
 				}); err != nil {
-					sLogger.Error().Err(err).Msgf("cannot add %s annotation to namespace", nextSuspendTime, n.Name)
+					sLogger.Error().Err(err).Msgf("cannot add '%s' annotation to namespace", eng.Options.Prefix+nextSuspendTime, n.Name)
 				}
 			}
 		}
 
-		sLogger.Debug().Msgf("suspender loop ended, duration: %s", time.Since(start))
+		sLogger.Debug().Str("step", stepName).Msgf("suspender loop ended, duration: %s", time.Since(start))
 	}
 }

--- a/engine/watcher.go
+++ b/engine/watcher.go
@@ -23,6 +23,7 @@ func (eng *Engine) Watcher(ctx context.Context, cs *kubernetes.Clientset) {
 		start := time.Now()
 		wLogger.Debug().Int("inventory_id", id).
 			Msg("starting new namespaces inventory")
+
 		ns, err := cs.CoreV1().Namespaces().List(ctx, metav1.ListOptions{}) // TODO: think about adding a label to filter here
 		if err != nil {
 			wLogger.Fatal().
@@ -33,13 +34,18 @@ func (eng *Engine) Watcher(ctx context.Context, cs *kubernetes.Clientset) {
 		eng.Mutex.Lock()
 		// create fresh new variables for metrics
 		var wllen, runningNs, suspendedNs, unknownNs int
+
 		// look for new namespaces to watch
+		wLogger.Debug().Msgf("parsing namespaces list")
 		for _, n := range ns.Items {
 			if value, ok := n.Annotations[eng.Options.Prefix+controllerName]; ok {
+				wLogger.Debug().Msgf("found annotation '%s'", eng.Options.Prefix+controllerName)
 				if value == eng.Options.ControllerName {
 					eng.Wl <- n
-					wLogger.Trace().Msgf("namespace %s sent to suspender", n.Name)
+					wLogger.Debug().Msgf("annotation '%s' matches controller name (%s)", eng.Options.Prefix+controllerName, eng.Options.ControllerName)
+					wLogger.Debug().Msgf("namespace %s sent to suspender", n.Name)
 					wllen++
+
 					// try to get the desiredState annotation
 					if state, ok := n.Annotations[eng.Options.Prefix+DesiredState]; ok {
 						// increment variables for metrics
@@ -51,26 +57,32 @@ func (eng *Engine) Watcher(ctx context.Context, cs *kubernetes.Clientset) {
 						default:
 							unknownNs++
 						}
+					} else {
+						wLogger.Warn().Msgf("annotation '%s' not found", eng.Options.Prefix+DesiredState)
 					}
 				}
 			}
 		}
+
 		// update metrics
-		wLogger.Debug().Msgf("channel length: %d", wllen)
+		wLogger.Debug().Msgf("Metric - channel length: %d", wllen)
 		eng.MetricsServ.WatchlistLength.Set(float64(wllen))
 
-		wLogger.Debug().Msgf("running namespaces: %d", runningNs)
+		wLogger.Debug().Msgf("Metric - running namespaces: %d", runningNs)
 		eng.MetricsServ.NumRunningNamspaces.Set(float64(runningNs))
 
-		wLogger.Debug().Msgf("suspended namespaces: %d", suspendedNs)
+		wLogger.Debug().Msgf("Metric - suspended namespaces: %d", suspendedNs)
 		eng.MetricsServ.NumSuspendedNamspaces.Set(float64(suspendedNs))
 
-		wLogger.Debug().Msgf("unknown namespaces: %d", unknownNs)
+		wLogger.Debug().Msgf("Metric - unknown namespaces: %d", unknownNs)
 		eng.MetricsServ.NumUnknownNamespaces.Set(float64(unknownNs))
 
 		eng.Mutex.Unlock()
+
+		// Question: Why not add `Int("inventory_id", id)` to every log line ?
 		wLogger.Debug().Int("inventory_id", id).Msg("namespaces inventory ended")
 		wLogger.Debug().Int("inventory_id", id).Msgf("inventory duration: %s", time.Since(start))
+
 		id++
 		time.Sleep(time.Duration(eng.Options.WatcherIdle) * time.Second)
 	}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 func main() {
 	var opt engine.Options
 	var err error
+
 	fs := flag.NewFlagSetWithEnvPrefix(os.Args[0], "KUBE_NS_SUSPENDER", 0)
 	fs.StringVar(&opt.LogLevel, "log-level", "debug", "Log level")
 	fs.StringVar(&opt.TZ, "timezone", "Europe/Paris", "Timezone to use")
@@ -55,7 +56,7 @@ func main() {
 		log.Fatal().Err(err).Msg("cannot create new engine")
 	}
 	eng.Logger.Info().Msgf("engine successfully created in %s", time.Since(start))
-	eng.Logger.Info().Msgf("kube-ns-suspender version %s (built %s)", Version, BuildDate)
+	eng.Logger.Info().Msgf("kube-ns-suspender version '%s' (built %s)", Version, BuildDate)
 
 	// start web ui
 	if eng.Options.EmbeddedUI || eng.Options.WebUIOnly {
@@ -104,6 +105,7 @@ func main() {
 	// disable k8s warnings
 	if eng.Options.NoKubeWarnings {
 		config.WarningHandler = rest.NoWarnings{}
+		eng.Logger.Info().Msgf("Kubernetes warnings disabled")
 	}
 
 	// create the clientset
@@ -114,6 +116,7 @@ func main() {
 	}
 	eng.Logger.Info().Msgf("clientset successfully created in %s", time.Since(start))
 
+	eng.Logger.Info().Msgf("starting 'Watcher' and 'Suspender' routines")
 	ctx := context.Background()
 	go eng.Watcher(ctx, clientset)
 	go eng.Suspender(ctx, clientset)


### PR DESCRIPTION
- chore: Rename watcher logger variable
- chore: Minor logs update on 'main.go'
- chore: Minor logs update on 'engine/watcher.go'
- chore: Remove un-needed 'namespace' reference from logger in 'engine/suspender.go'
- refactor: Add tons of logs on 'engine/suspender.go'
- chore: Add 'inventory_id' on every log statement on 'engine/watcher.go'
