### PR TITLE
fix: nextSuspendTime does not need eng.RunningDuration anymore

### DIFF
--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches:
       - main
+      - feature/*
+      - chore/*
+      - fix/*
+      - refactor/*
 
   workflow_dispatch:
     inputs:

--- a/engine/suspender.go
+++ b/engine/suspender.go
@@ -135,10 +135,11 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 					continue
 				}
 
-				if time.Now().Local().Sub(nextSuspendAt) <= eng.RunningDuration {
+				nextSuspendDuration := time.Now().Local().Sub(nextSuspendAt)
+				if nextSuspendDuration < 0 {
 					// NOTICE: Same code than L200-L228
 					sLogger.Debug().Str("step", stepName).
-						Msgf("%s is less or equal to now (value: %d, now: %d), updating annotation '%s' to '%s'", nextSuspendTime, suspendAt, now, eng.Options.Prefix+DesiredState, Suspended)
+					Msgf("%s is less or equal to now (value: %d), updating annotation '%s' to '%s'", nextSuspendTime, nextSuspendDuration, eng.Options.Prefix+DesiredState, Suspended)
 					if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 						sLogger.Trace().Str("step", stepName).Msgf("get namespace")
 						res, err := cs.CoreV1().Namespaces().Get(ctx, n.Name, metav1.GetOptions{})
@@ -316,7 +317,7 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 
 			// now we can check if patchedResourcesCounter is > 0 and add nextSuspendTime depending of the result
 			if patchedResourcesCounter > 0 {
-				sLogger.Debug().Msgf("namespace has been unsuspended manually, adding the annotation '%s' to it", eng.Options.Prefix+nextSuspendTime)
+				sLogger.Debug().Msgf("namespace has been unsuspended manually, adding the annotation '%s' to it (engined configured duration: '%s')", eng.Options.Prefix+nextSuspendTime, eng.RunningDuration)
 				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					sLogger.Trace().Str("step", stepName).Msg("get namespace")
 					res, err := cs.CoreV1().Namespaces().Get(ctx, n.Name, metav1.GetOptions{})
@@ -332,9 +333,9 @@ func (eng *Engine) Suspender(ctx context.Context, cs *kubernetes.Clientset) {
 						However, it makes it easier to detect if the date is passed, as it returns
 						a complete date, not only the hours and minutes of the day.
 					*/
-					sLogger.Trace().Str("step", stepName).Msgf("setting namespace annotation '%s=%s'", eng.Options.Prefix+nextSuspendTime, time.Now().Local())
-					res.Annotations[eng.Options.Prefix+nextSuspendTime] = time.Now().Local().
-						Add(eng.RunningDuration).Format(time.RFC822Z)
+					nextSuspendTime := time.Now().Local().Add(eng.RunningDuration).Format(time.RFC822Z)
+					sLogger.Trace().Str("step", stepName).Msgf("setting namespace annotation '%s=%s'", eng.Options.Prefix+nextSuspendTime, nextSuspendTime)
+					res.Annotations[eng.Options.Prefix+nextSuspendTime] = nextSuspendTime
 
 					sLogger.Trace().Str("step", stepName).Msg("update namespace")
 					_, err = cs.CoreV1().Namespaces().Update(ctx, res, metav1.UpdateOptions{})


### PR DESCRIPTION
- fix: nextSuspendTime handling
- ci: Enable e2e tests on PR against branches other than 'main'

And tests pass 🎉 

![image](https://user-images.githubusercontent.com/1590399/160413204-23ad5ed4-d867-4fdf-9128-39a88ab5ac76.png)
