### PR TITLE
fix(webui): fix missing file in templates imports

### DIFF
--- a/webui/webui.go
+++ b/webui/webui.go
@@ -118,7 +118,7 @@ func createRouter(l zerolog.Logger, prefix, cn, v, bd string) *mux.Router {
 // homePage handles the home page, with the drop-down menu to unsuspend a namespace
 func (h handler) homePage(w http.ResponseWriter, r *http.Request, l zerolog.Logger) {
 	tmpl, err := template.ParseFS(assets, "assets/home.html", "assets/templates/head.html",
-		"assets/templates/style.html", "assets/templates/footer.html")
+		"assets/templates/style.html")
 	if err != nil {
 		l.Error().Err(err).Str("page", "/").Msg("cannot parse files")
 	}
@@ -154,7 +154,7 @@ func (h handler) homePage(w http.ResponseWriter, r *http.Request, l zerolog.Logg
 // namespace selected on the home page
 func (h handler) unsuspendPage(w http.ResponseWriter, r *http.Request, l zerolog.Logger) {
 	tmpl, err := template.ParseFS(assets, "assets/unsuspend.html", "assets/templates/head.html",
-		"assets/templates/style.html", "assets/templates/footer.html")
+		"assets/templates/style.html")
 	if err != nil {
 		l.Error().Err(err).Str("page", "/unsuspend").Msg("cannot parse files")
 	}
@@ -190,7 +190,7 @@ func (h handler) unsuspendPage(w http.ResponseWriter, r *http.Request, l zerolog
 // bugPage handles the pages with contact informations in case of a bug
 func (h handler) bugPage(w http.ResponseWriter, r *http.Request, l zerolog.Logger) {
 	tmpl, err := template.ParseFS(assets, "assets/bug.html", "assets/templates/head.html",
-		"assets/templates/style.html", "assets/templates/footer.html")
+		"assets/templates/style.html")
 	if err != nil {
 		l.Error().Err(err).Str("page", "/bug").Msg("cannot parse files")
 	}
@@ -208,7 +208,7 @@ func (h handler) bugPage(w http.ResponseWriter, r *http.Request, l zerolog.Logge
 // errorPage handles the various 404 errors that can occur
 func (h handler) errorPage(w http.ResponseWriter, r *http.Request, l zerolog.Logger) {
 	tmpl, err := template.ParseFS(assets, "assets/404.html", "assets/templates/head.html",
-		"assets/templates/style.html", "assets/templates/footer.html")
+		"assets/templates/style.html")
 	if err != nil {
 		l.Error().Err(err).Str("page", "/bug").Msg("cannot parse templates")
 	}
@@ -228,7 +228,7 @@ func (h handler) errorPage(w http.ResponseWriter, r *http.Request, l zerolog.Log
 // state, a searchbar etc...
 func (h handler) listPage(w http.ResponseWriter, r *http.Request, l zerolog.Logger) {
 	tmpl, err := template.ParseFS(assets, "assets/list.html", "assets/templates/head.html",
-		"assets/templates/style.html", "assets/templates/footer.html")
+		"assets/templates/style.html")
 	if err != nil {
 		l.Error().Err(err).Str("page", "/list").Msg("cannot parse files")
 	}


### PR DESCRIPTION
fixes the invalid memory address

```
{"level":"error","routine":"webui","error":"template: pattern matches no files: `assets/templates/footer.html`","page":"/","time":"2022-04-06T16:46:25+02:00","message":"cannot parse files"}
2022/04/06 16:46:25 http: panic serving 10.103.65.2:1230: runtime error: invalid memory address or nil pointer dereference
goroutine 587 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1801 +0xb9
panic({0x12f18e0, 0x209d700})
	/usr/local/go/src/runtime/panic.go:1047 +0x266
html/template.(*Template).escape(0x0)
	/usr/local/go/src/html/template/template.go:97 +0x34
html/template.(*Template).Execute(0x0, {0x16297e0, 0xc0004c6000}, {0x13a03a0, 0xc00073c090})
	/usr/local/go/src/html/template/template.go:121 +0x32
github.com/govirtuo/kube-ns-suspender/webui.handler.homePage({{0xc0000e2048, 0x12}, {0x7ffd3aa2b694, 0x11}, {0x163ece0, 0x29}, {0x1622d60, 0x17}}, {0x1648e20, 0xc0004c6000}, ...)
	/build/webui/webui.go:147 +0x397
github.com/govirtuo/kube-ns-suspender/webui.(*loggingHandler).ServeHTTP(0xc0000f8300, {0x1648e20, 0xc0004c6000}, 0xc0004e59f8)
	/build/webui/webui.go:286 +0x87
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0002020c0, {0x1648e20, 0xc0004c6000}, 0xc0000f8200)
	/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf
net/http.serverHandler.ServeHTTP({0xc0001aa300}, {0x1648e20, 0xc0004c6000}, 0xc0000f8200)
	/usr/local/go/src/net/http/server.go:2878 +0x43b
net/http.(*conn).serve(0xc0001b20a0, {0x164c7d8, 0xc00037f770})
	/usr/local/go/src/net/http/server.go:1929 +0xb08
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3033 +0x4e8
```