### PR TITLE
fix: Remove namespace property from CluserRoleBinding subjects to work with Kustomize nameReference

### DIFF
--- a/manifests/run/base/rbac.yaml
+++ b/manifests/run/base/rbac.yaml
@@ -46,4 +46,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-ns-suspender
-  namespace: kube-ns-suspender


### PR DESCRIPTION
## Overview

The "kustomize" way to fix an issue we faced in our private overlay is to remove the `namespace` property in the `ClusterRoleBinding` "root" object so that the builtin `nameReference` helper of `kustomize` can do its job.

https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#builtin-namereference


## Details

In a private overlay, we have 

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: kube-ns-suspender
nameSuffix: '-main'

resources:
# Base
- github.com/govirtuo/kube-ns-suspender/manifests/run/base?ref=v2.0.11

patchesStrategicMerge:
- patches/deployment.yaml
- patches/ingress.yaml

images:
  - name: ghcr.io/govirtuo/kube-ns-suspender
    newName: ghcr.io/govirtuo/kube-ns-suspender
    newTag: v2.0.11
```

With the current version of `kube-ns-suspender` manifests, we face an issue regarding the `nameSuffix` helper:

![image](https://user-images.githubusercontent.com/1590399/171363839-66279dd6-3703-4cf6-b922-96cae32fc3c0.png)

Removing the namespace as defined in this PR fix the issue.