### PR TITLE
fix(INF-538): add an option to set watchlist size

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,22 +70,23 @@ The suspender function does all the work of reading namespaces/resources annotat
 
 ### Flags
 
-| Flag                   | Description                                       |      Default      | Environment variable                   |
-| ---------------------- | ------------------------------------------------- | :---------------: | -------------------------------------- |
-| `--controller-name`    | Unique name of the controller                     | kube-ns-suspender | `KUBE_NS_SUSPENDER_CONTROLLER_NAME`    |
-| `--human`              | Disable JSON logging                              |       false       | `KUBE_NS_SUSPENDER_HUMAN`              |
-| `--log-level`          | Log level                                         |       debug       | `KUBE_NS_SUSPENDER_LOG_LEVEL`          |
-| `--no-kube-warnings`   | Disable Kubernetes warnings                       |       false       | `KUBE_NS_SUSPENDER_NO_KUBE_WARNINGS`   |
-| `--pprof`              | Start pprof server                                |       false       | `KUBE_NS_SUSPENDER_PPROF`              |
-| `--pprof-addr`         | Address and port to use with pprof                |       :4455       | `KUBE_NS_SUSPENDER_PPROF_ADDR`         |
-| `--prefix`             | Prefix to use for annotations                     | kube-ns-suspender | `KUBE_NS_SUSPENDER_PREFIX`             |
-| `--running-duration`   | Running duration                                  |        4h         | `KUBE_NS_SUSPENDER_RUNNING_DURATION`   |
-| `--slack-channel-link` | Link of the help Slack channel in the UI bug page |        ""         | `KUBE_NS_SUSPENDER_SLACK_CHANNEL_LINK` |
-| `--slack-channel-name` | Name of the help Slack channel in the UI bug page |        ""         | `KUBE_NS_SUSPENDER_SLACK_CHANNEL_NAME` |
-| `--timezone`           | Timezone to use                                   |   Europe/Paris    | `KUBE_NS_SUSPENDER_TIMEZONE`           |
-| `--ui-embedded`        | Start UI in background                            |       false       | `KUBE_NS_SUSPENDER_UI_EMBEDDED`        |
-| `--ui-only`            | Start UI only                                     |       false       | `KUBE_NS_SUSPENDER_UI_ONLY`            |
-| `--watcher-idle`       | Watcher idle duration in seconds                  |        15         | `KUBE_NS_SUSPENDER_WATCHER_IDLE`       |
+| Flag                   | Description                                                       |      Default      | Environment variable                   |
+| ---------------------- | ----------------------------------------------------------------- | :---------------: | -------------------------------------- |
+| `--controller-name`    | Unique name of the controller                                     | kube-ns-suspender | `KUBE_NS_SUSPENDER_CONTROLLER_NAME`    |
+| `--human`              | Disable JSON logging                                              |       false       | `KUBE_NS_SUSPENDER_HUMAN`              |
+| `--log-level`          | Log level                                                         |       debug       | `KUBE_NS_SUSPENDER_LOG_LEVEL`          |
+| `--no-kube-warnings`   | Disable Kubernetes warnings                                       |       false       | `KUBE_NS_SUSPENDER_NO_KUBE_WARNINGS`   |
+| `--pprof`              | Start pprof server                                                |       false       | `KUBE_NS_SUSPENDER_PPROF`              |
+| `--pprof-addr`         | Address and port to use with pprof                                |       :4455       | `KUBE_NS_SUSPENDER_PPROF_ADDR`         |
+| `--prefix`             | Prefix to use for annotations                                     | kube-ns-suspender | `KUBE_NS_SUSPENDER_PREFIX`             |
+| `--running-duration`   | Running duration                                                  |        4h         | `KUBE_NS_SUSPENDER_RUNNING_DURATION`   |
+| `--slack-channel-link` | Link of the help Slack channel in the UI bug page                 |        ""         | `KUBE_NS_SUSPENDER_SLACK_CHANNEL_LINK` |
+| `--slack-channel-name` | Name of the help Slack channel in the UI bug page                 |        ""         | `KUBE_NS_SUSPENDER_SLACK_CHANNEL_NAME` |
+| `--timezone`           | Timezone to use                                                   |   Europe/Paris    | `KUBE_NS_SUSPENDER_TIMEZONE`           |
+| `--ui-embedded`        | Start UI in background                                            |       false       | `KUBE_NS_SUSPENDER_UI_EMBEDDED`        |
+| `--ui-only`            | Start UI only                                                     |       false       | `KUBE_NS_SUSPENDER_UI_ONLY`            |
+| `--watcher-idle`       | Watcher idle duration in seconds                                  |        15         | `KUBE_NS_SUSPENDER_WATCHER_IDLE`       |
+| `--watchlist-size`     | Size of the watchlist containing namespaces waiting to be handled |        512        | `KUBE_NS_SUSPENDER_WATCHLIST_SIZE`       |
 
 ### Resources
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"errors"
 	"os"
 	"sync"
 	"time"
@@ -43,6 +44,7 @@ type Engine struct {
 
 type Options struct {
 	WatcherIdle               int
+	WatchListSize             int
 	RunningDuration           string
 	LogLevel                  string
 	TZ                        string
@@ -58,9 +60,14 @@ type Options struct {
 // New returns a new engine instance
 func New(opt Options) (*Engine, error) {
 	var err error
+
+	if opt.WatchListSize < 1 {
+		return nil, errors.New("watchlist size cannot be lower than 1. A default value of 512 is adviced")
+	}
+
 	e := Engine{
 		Logger:  zerolog.New(os.Stderr).With().Timestamp().Logger(),
-		Wl:      make(chan v1.Namespace, 50),
+		Wl:      make(chan v1.Namespace, opt.WatchListSize),
 		Options: opt,
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,7 +62,7 @@ func New(opt Options) (*Engine, error) {
 	var err error
 
 	if opt.WatchListSize < 1 {
-		return nil, errors.New("watchlist size cannot be lower than 1. A default value of 512 is advised")
+		return nil, errors.New("watchlist size cannot be lower than 1. If in doubt, please use default value")
 	}
 
 	e := Engine{

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,7 +62,7 @@ func New(opt Options) (*Engine, error) {
 	var err error
 
 	if opt.WatchListSize < 1 {
-		return nil, errors.New("watchlist size cannot be lower than 1. A default value of 512 is adviced")
+		return nil, errors.New("watchlist size cannot be lower than 1. A default value of 512 is advised")
 	}
 
 	e := Engine{

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	fs.StringVar(&opt.PProfAddr, "pprof-addr", ":4455", "Address and port to use with pprof")
 	fs.StringVar(&opt.SlackChannelName, "slack-channel-name", "", "Name of the help Slack channel in the UI bug page")
 	fs.StringVar(&opt.SlackChannelLink, "slack-channel-link", "", "Link of the helm Slack channel in the UI bug page")
+	fs.IntVar(&opt.WatchListSize, "watchlist-size", 512, "Size of the watchlist containing namespaces waiting to be handled")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		log.Fatal().Err(err).Msg("cannot parse flags")
 	}
@@ -91,6 +92,7 @@ func main() {
 
 	eng.Logger.Debug().Msgf("timezone: %s", time.Local.String())
 	eng.Logger.Debug().Msgf("watcher idle: %s", time.Duration(eng.Options.WatcherIdle)*time.Second)
+	eng.Logger.Debug().Msgf("watchlist size: %d", eng.Options.WatchListSize)
 	eng.Logger.Debug().Msgf("running duration: %s", eng.RunningDuration)
 	eng.Logger.Debug().Msgf("log level: %s", eng.Options.LogLevel)
 	eng.Logger.Debug().Msgf("json logging: %v", !eng.Options.HumanLogs)


### PR DESCRIPTION
This PR allows a user to explicitly set the size of the buffer containing the list of namespaces waiting to be (un)suspended.

Having a number close to reality (in our case 50) causes `kube-ns-suspender` to get blocked until it crashes.

Please note that the `512` value that is now advised is just an arbitrary value that seems to be "good enough", at least in our case. It might evolve with time and experience.