### PR TITLE
fix: align namespaces names to the left in the web ui

### DIFF
--- a/webui/assets/home.html
+++ b/webui/assets/home.html
@@ -46,7 +46,7 @@
       </tr>
       {{range .NamespacesList.Namespaces}}
         <tr>
-          <td style="text-align: center;"><code>{{.Name}}</code></td>
+          <td><code>{{.Name}}</code></td>
           <td style="text-align: center;">
             {{if eq .State "Running"}}
             <span class="badge badge-pill badge-info">{{.State}}</span>


### PR DESCRIPTION
this PR closes #94
