### PR TITLE
feat: improve accuracy of uptime metric function

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -70,8 +70,9 @@ func (s *Server) Start() error {
 
 // goroutine to update the Uptime metric
 func (s *Server) uptimeCounter() {
+	start := time.Now()
 	for {
-		s.Uptime.Add(5)
+		s.Uptime.Set(time.Since(start).Seconds())
 		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
The initial way of calculating the uptime may introduce drift with time. This one keep the actual start time and compute the uptime from it.