### PR TITLE
Remove mutex to fix deadlock

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"errors"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/govirtuo/kube-ns-suspender/metrics"
@@ -35,7 +34,6 @@ const (
 
 type Engine struct {
 	Logger          zerolog.Logger
-	Mutex           sync.Mutex
 	Wl              chan v1.Namespace
 	MetricsServ     metrics.Server
 	RunningDuration time.Duration

--- a/engine/watcher.go
+++ b/engine/watcher.go
@@ -18,9 +18,7 @@ func (eng *Engine) Watcher(ctx context.Context, cs *kubernetes.Clientset) {
 
 	var id int
 	for {
-		eng.Mutex.Lock()
 		wLogger := eng.Logger.With().Str("routine", "watcher").Int("inventory_id", id).Logger()
-		wLogger.Trace().Msg("engine mutex is locked")
 
 		start := time.Now()
 		wLogger.Debug().Msg("starting new namespaces inventory")
@@ -78,9 +76,6 @@ func (eng *Engine) Watcher(ctx context.Context, cs *kubernetes.Clientset) {
 
 		wLogger.Debug().Msgf("Metric - unknown namespaces: %d", unknownNs)
 		eng.MetricsServ.NumUnknownNamespaces.Set(float64(unknownNs))
-
-		eng.Mutex.Unlock()
-		wLogger.Trace().Msg("engine mutex is unlocked")
 
 		// Question: Why not add `Int("inventory_id", id)` to every log line ?
 		wLogger.Debug().Msg("namespaces inventory ended")

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -226,7 +226,7 @@ func (h handler) suspendPage(w http.ResponseWriter, r *http.Request, l zerolog.L
 
 	p.HasMessage = true
 	p.Message = fmt.Sprintf("Namespace %s successfully suspended.", p.CurrentNamespace.Name)
-	l.Info().Str("page", "/suspended").Msgf("suspendeded namespace %s using web ui", p.CurrentNamespace.Name)
+	l.Info().Str("page", "/suspended").Msgf("suspended namespace %s using web ui", p.CurrentNamespace.Name)
 	err = tmpl.Execute(w, p)
 	if err != nil {
 		l.Error().Err(err).Str("page", "/suspended").Msg("cannot execute template")


### PR DESCRIPTION
Fix for https://github.com/govirtuo/kube-ns-suspender/issues/110

I have found a case where it can deadlock which I have reproduced locally.  I think the WatchListSize makes it more likely to occur because the channel will block if the number of messages in the channel reaches the WatchListSize so I set the WatchListSize to 1 to reproduce the issue.

In my reproduction, the watcher and suspender routines both start at the same time and try to acquire a Mutex lock:
https://github.com/govirtuo/kube-ns-suspender/blob/v2.5.0/engine/suspender.go#L37
https://github.com/govirtuo/kube-ns-suspender/blob/v2.5.0/engine/watcher.go#L21

The watcher wins the race and acquires the lock.  The suspender blocks on the above line.

The watcher then lists out the namespaces and send them over the buffered channel:
https://github.com/govirtuo/kube-ns-suspender/blob/v2.5.0/engine/watcher.go#L47

However, once the buffered channel is full, this becomes a blocking operation. The watcher is now blocked waiting for the suspender to read from the channel while the suspender is blocked waiting for the watcher to yield the mutex. This is a deadlock.

So it is pretty likely to occur when the WatchListSize is small because the buffered channel gets filled quickly.  With the default 512 WatchListSize, it probably only occurs when the suspender gets really busy suspending stuff so that the channel fills up in the mean time.

The mutex doesn't actually appear to be needed for anything because the channels will block as need so I simply remove it in this PR.  In my testing, everything behaved as expected.