### PR TITLE
fix: add namespace for CRB in base manifests

### DIFF
--- a/manifests/run/base/rbac.yaml
+++ b/manifests/run/base/rbac.yaml
@@ -46,3 +46,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-ns-suspender
+  namespace: kube-ns-suspender


### PR DESCRIPTION
This fixes #116 